### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ From within the project directory
 
 #### Start the watcher. When you save changes to your files, the tests get re-run
 
-	gulp watch
+	npm run test


### PR DESCRIPTION
It would be better not to require an unspoken global install of gulp, especially when gulp watch is already added to the package.json (and the rest of the readme is very explicit)
